### PR TITLE
Use auto-value-extension-util to replace boilerplate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ repositories {
 dependencies {
   compile 'com.squareup:javapoet:1.1.0'
   compile 'com.google.auto.service:auto-service:1.0-rc2'
-  compile 'com.google.auto.value:auto-value:1.2-rc1'
+  compile 'com.google.auto.value:auto-value:1.2'
+  compile 'com.gabrielittner.auto.value:auto-value-extension-util:0.1.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.truth:truth:0.28'

--- a/src/test/java/com/squareup/auto/value/redacted/AutoValueRedactedExtensionTest.java
+++ b/src/test/java/com/squareup/auto/value/redacted/AutoValueRedactedExtensionTest.java
@@ -116,4 +116,43 @@ public final class AutoValueRedactedExtensionTest {
         .and()
         .generatesSources(expectedSource);
   }
+
+  @Test public void prefixedMethods() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+            + "package test;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "@AutoValue public abstract class Test {\n"
+            + "@Redacted public abstract String getA();\n"
+            + "public abstract String getB();\n"
+            + "@Redacted public abstract boolean isC();\n"
+            + "public abstract boolean isD();\n"
+            + "}\n"
+    );
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/AutoValue_Test", ""
+            + "package test;\n"
+            + "import java.lang.Override;\n"
+            + "import java.lang.String;\n"
+            + "final class AutoValue_Test extends $AutoValue_Test {\n"
+            + "  AutoValue_Test(String a, String b, boolean c, boolean d) {\n"
+            + "    super(a, b, c, d);\n"
+            + "  }\n"
+            + "  @Override public final String toString() {\n"
+            + "    return \"Test{\"\n"
+            + "        + \"a=\" + \"██\" + \", \"\n"
+            + "        + \"b=\" + getB() + \", \"\n"
+            + "        + \"c=\" + \"██\" + \", \"\n"
+            + "        + \"d=\" + isD()\n"
+            + "        + '}';\n"
+            + "  }\n"
+            + "}\n"
+    );
+
+    assertAbout(javaSources())
+            .that(Arrays.asList(redacted, nullable, source))
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .and()
+            .generatesSources(expectedSource);
+  }
 }


### PR DESCRIPTION
I've extracted some parts of `auto-value-cursor` into a separate library and Ryan added the `Property` class of his extensions to it. Besides removing some boilerplate code this pull request will
- support get/is prefixes properly (fixes #13 )
- add support for generic AutoValue classes

I didn't add a test for the latter because it's tested in the library https://github.com/gabrielittner/auto-value-extension-util