### PR TITLE
Add support for incremental annotation processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,10 @@ repositories {
 
 dependencies {
   compile 'com.squareup:javapoet:1.7.0'
-  compile 'com.google.auto.value:auto-value:1.2'
+  compile 'com.google.auto.value:auto-value:1.6.3'
   compileOnly 'com.google.auto.service:auto-service:1.0-rc2'
 
+  testCompile 'com.google.auto.value:auto-value-annotations:1.6.3'
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.truth:truth:0.28'
   testCompile 'com.google.testing.compile:compile-testing:0.9'

--- a/src/main/java/com/squareup/auto/value/redacted/AutoValueRedactedExtension.java
+++ b/src/main/java/com/squareup/auto/value/redacted/AutoValueRedactedExtension.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -158,5 +159,10 @@ public final class AutoValueRedactedExtension extends AutoValueExtension {
     }
 
     return Collections.unmodifiableSet(set);
+  }
+
+  @Override
+  public IncrementalExtensionType incrementalType(ProcessingEnvironment processingEnvironment) {
+    return IncrementalExtensionType.ISOLATING;
   }
 }


### PR DESCRIPTION
Closes #22 

Test manually: I created two non-related classes using redacted extension, updated one class and run a build. By checking the timestamp, I find only the modified class has been recompiled.